### PR TITLE
"require" statements must always be generated with unix-style paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "12"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/module.js
+++ b/module.js
@@ -15,12 +15,16 @@ class Link extends Code {
         this.importedCodeRef = importedCodeRef;
     }
 
+    unixify(str) {
+        return str.replace(/[\\\/]+/g, '/');
+    }
+
     toString() {
         if (this.importedCodeRef.external) {
-            return `require('${this.importedCodeRef.getPath()}')`;
+            return `require('${this.unixify(this.importedCodeRef.getPath())}')`;
         }
-        const path = relative(Path.resolve(this.hostCodeRef.getPath(), '..'),
-            this.importedCodeRef.getPath());
+        const path = this.unixify(relative(Path.resolve(this.hostCodeRef.getPath(), '..'),
+            this.importedCodeRef.getPath()));
         return `require('${/\./.test(path) ? path : `./${path}`}')`;
     }
 }

--- a/test/code.js
+++ b/test/code.js
@@ -1,5 +1,6 @@
 const Assert = require('assert');
 const { Code } = require('../code');
+var os = require("os");
 
 describe(__filename, () => {
     it('should create an empty snippet code', () => {
@@ -44,7 +45,7 @@ describe(__filename, () => {
     });
 
     it('should prettyprint js code', () => {
-        Assert.equal('function fn() {\n    return \'foo\';\n}',
+        Assert.equal(`function fn() {${os.EOL}    return \'foo\';${os.EOL}}`,
             Code.pretty(new Code(`function fn() { return 'foo' }`)));
     });
 });

--- a/test/location.js
+++ b/test/location.js
@@ -1,30 +1,31 @@
 const Assert = require('assert');
 const { Location } = require('../location');
+const Path = require('path');
 
 describe(__filename, () => {
     it('should base location', () => {
         const base = new Location('path/to/root');
-        Assert.equal('path/to/root', base.getPath());
+        Assert.equal(`path/to/root`, base.getPath());
     });
 
     it('should create relative location', () => {
         const base = new Location('path/to/root');
-        Assert.equal('path/to', base.relative('..').getPath());
+        Assert.equal(`path${Path.sep}to`, base.relative('..').getPath());
     });
 
     it('should mutate relative location based on base location change', () => {
         const base = new Location('path/to/root');
         const foo = base.relative('../foo');
         const bar = base.relative('../other/deep/bar');
-        Assert.equal('path/to/foo', foo.getPath());
-        Assert.equal('path/to/other/deep/bar', bar.getPath());
+        Assert.equal(`path${Path.sep}to${Path.sep}foo`, foo.getPath());
+        Assert.equal(`path${Path.sep}to${Path.sep}other${Path.sep}deep${Path.sep}bar`, bar.getPath());
 
         base.root = 'new/root';
-        Assert.equal('new/foo', foo.getPath());
-        Assert.equal('new/other/deep/bar', bar.getPath());
+        Assert.equal(`new${Path.sep}foo`, foo.getPath());
+        Assert.equal(`new${Path.sep}other${Path.sep}deep${Path.sep}bar`, bar.getPath());
 
         base.set(new Location('new/path').relative('..'));
-        Assert.equal('other/deep/bar', bar.getPath());
+        Assert.equal(`other${Path.sep}deep${Path.sep}bar`, bar.getPath());
         Assert.equal('foo', foo.getPath());
     });
 });

--- a/test/module.js
+++ b/test/module.js
@@ -1,6 +1,7 @@
 const Assert = require('assert');
 const { createModule, ModuleLocation } = require('../module');
 const { Location } = require('../location');
+const Path = require('path');
 
 describe(__filename, () => {
     it('should create an empty module', () => {
@@ -210,8 +211,8 @@ describe(__filename, () => {
             one.import('bar', three);
         }, /The var bar with the same name already defined in module .\/path/);
     });
-
+    
     it('should fail to get relative from external module', () => {
-        Assert.equal('two/path', createModule('two').relative('path').getPath());
+        Assert.equal(`two${Path.sep}path`, createModule('two').relative('path').getPath());
     });
 });

--- a/test/readme.js
+++ b/test/readme.js
@@ -1,4 +1,5 @@
 const Assert = require('assert');
+var os = require("os");
 
 describe(__filename, () => {
     it('should do read example', () => {
@@ -29,8 +30,8 @@ describe(__filename, () => {
             .add(new Code('})'));
         Assert.equal(`const barvar = require('./other/bar');describe(__filename, () => ` +
         `{it('should do some test', () => {const foo = 10;const bar = false;})})`, foo.toString());
-        Assert.equal('const barvar = require(\'./other/bar\');\n\ndescribe(__filename,' +
-        ' () => {\n    it(\'should do some test\', () => {\n        ' +
-        'const foo = 10;\n        const bar = false;\n    });\n});', Code.pretty(foo));
+        Assert.equal(`const barvar = require(\'./other/bar\');${os.EOL}${os.EOL}describe(__filename,` +
+        ` () => {${os.EOL}    it(\'should do some test\', () => {${os.EOL}        ` +
+        `const foo = 10;${os.EOL}        const bar = false;${os.EOL}    });${os.EOL}});`, Code.pretty(foo));
     });
 });


### PR DESCRIPTION
When using this library from a Windows environment, paths are generated using backslashes ( '\\' ).
While this is generally not an issue,  it causes a severe bug when generating "require" statements.

For that particular case, "require" statements should ALWAYS be generated using unix-style paths ( '/' ),
no matter if running from a Windows machine or not.

This PR is for ensuring that "require" statements are always generated with unix-style paths, regardless of the OS the library is being executed on.

As a side note, many Unit Tests on this library will fail when running from a Windows machine, due to the assumption of how the paths are generated.